### PR TITLE
Requestor autofillID check and Database update

### DIFF
--- a/app/src/main/java/com/example/knox/systemComponents/Requestor.java
+++ b/app/src/main/java/com/example/knox/systemComponents/Requestor.java
@@ -84,7 +84,8 @@ public final class Requestor extends AutofillService {
         RemoteViews userNamePresentation = new RemoteViews(this.getPackageName(), android.R.layout.simple_list_item_1);
         RemoteViews passwordPresentation = new RemoteViews(this.getPackageName(), android.R.layout.simple_list_item_1);
         //dao.insertAll(new Credentials("eller010", "password", parsedStruct.URL));
-        Credentials cred = dao.getFullCred(parsedStruct.URL);
+        //Credentials cred = dao.getFullCred(parsedStruct.URL);
+        Credentials cred = Database.getInstance(getApplicationContext()).getFullCred(parsedStruct.URL);
 
         if(cred == null){
             cred = new Credentials("DNE","DNE","");
@@ -210,14 +211,14 @@ public final class Requestor extends AutofillService {
                     searchHTML(info);
                     //text field has some hint, check for id
                     if( (child.getHint().equals("Username") || searchHTML(info) == 1)
-                        && child.getAutofillHints() != null){
+                        && (child.getAutofillId() != null)){
                         parser.userID = child.getAutofillId();
                         try {
                             //only for save requests; fill requests will always have the null pointer
                             capturedUName = (String) child.getAutofillValue().getTextValue();
                         } catch (NullPointerException n) { /*do nothing*/}
                     } else if ( (child.getHint().equals("Password")|| searchHTML(info) == 2)
-                                && child.getAutofillHints() != null){
+                                && child.getAutofillId() != null){
                         parser.passID = child.getAutofillId();
                         try {
                             //same as other try/catch
@@ -239,7 +240,7 @@ public final class Requestor extends AutofillService {
      * @return 0 if no labels are found, 1 for username label, 2 for password label
      */
     public static int searchHTML(ViewStructure.HtmlInfo h){
-        if(h == null){
+        if(h == null || h.getAttributes() == null){
             return 0;
         }
         List<Pair<String, String>> att = h.getAttributes();


### PR DESCRIPTION
Requestor now calls only the Database instance interface to access credentials. Now checks for autofillID rather than hint, avoiding some false positives.